### PR TITLE
Support for transparent capes

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -75,7 +75,7 @@ class SkinViewer {
 
 		this.layer1Material = new THREE.MeshBasicMaterial({ map: this.skinTexture, side: THREE.FrontSide });
 		this.layer2Material = new THREE.MeshBasicMaterial({ map: this.skinTexture, transparent: true, opacity: 1, side: THREE.DoubleSide });
-		this.capeMaterial = new THREE.MeshBasicMaterial({ map: this.capeTexture });
+		this.capeMaterial = new THREE.MeshBasicMaterial({ map: this.capeTexture, transparent: true });
 
 		// scene
 		this.scene = new THREE.Scene();


### PR DESCRIPTION
Some players uses wings and long hairs as cape. Minecraft supports this.
I just don't know how to make two-side visibility of the cape texture. Adding `side: THREE.DoubleSide` attribute doesn't helps.